### PR TITLE
refactor: add an upper limit to maintenance_work_mem argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Options:
   -i, --skip-inactive-replication-slots                 Skip inactive replication slots check
   -r, --skip-sync-replication-connection                Skip sync replication connection check
   -m, --max-size-gb <MAX_SIZE_GB>                      Maximum index size in GB. Indexes larger than this will be excluded from reindexing [default: 1024]
-  -w, --maintenance-work-mem-gb <MAINTENANCE_WORK_MEM_GB>  Maximum maintenance work mem in GB [default: 1]
+  -w, --maintenance-work-mem-gb <MAINTENANCE_WORK_MEM_GB>  Maximum maintenance work mem in GB (max: 32 GB) [default: 1]
   -x, --max-parallel-maintenance-workers <MAX_PARALLEL_MAINTENANCE_WORKERS>  Maximum parallel maintenance workers. Must be less than max_parallel_workers/2 for safety. Use 0 for PostgreSQL default (typically 2) [default: 2]
   -c, --maintenance-io-concurrency <MAINTENANCE_IO_CONCURRENCY>  Maintenance IO concurrency. Controls the number of concurrent I/O operations during maintenance operations [default: 10]
   -l, --log-file <LOG_FILE>                             Log file path (default: reindexer.log in current directory) [default: reindexer.log]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,9 @@ use std::{env, fs, path::Path, sync::Arc};
 use tokio::sync::Semaphore;
 use tokio_postgres::NoTls;
 
+// Application constants
+const MAX_MAINTENANCE_WORK_MEM_GB: u64 = 32;
+
 mod checks;
 mod connection;
 mod deadlock;
@@ -102,12 +105,12 @@ struct Args {
     )]
     max_size_gb: u64,
 
-    /// Maximum maintenance work mem in GB (default: 1 GB )
+    /// Maximum maintenance work mem in GB (default: 1 GB, max: 32 GB)
     #[arg(
         short = 'w',
         long,
         default_value = "1",
-        help = "Maximum maintenance work mem in GB"
+        help = "Maximum maintenance work mem in GB (max: 32 GB)"
     )]
     maintenance_work_mem_gb: u64,
 
@@ -219,6 +222,14 @@ async fn main() -> Result<()> {
                 threshold
             ));
         }
+    }
+
+    // Validate maintenance work mem limit
+    if args.maintenance_work_mem_gb > MAX_MAINTENANCE_WORK_MEM_GB {
+        return Err(anyhow::anyhow!(
+            "Maintenance work mem ({}) exceeds maximum limit of {} GB. Please reduce the value.",
+            args.maintenance_work_mem_gb, MAX_MAINTENANCE_WORK_MEM_GB
+        ));
     }
 
     // Initialize logger


### PR DESCRIPTION
added a validation for `maintenance-work-mem-gb` to avoid setting it higher than 32GB. 