### PR TITLE
feat: add a new argument to reindex concurrently or not before starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Options:
   -c, --maintenance-io-concurrency <MAINTENANCE_IO_CONCURRENCY>  Maintenance IO concurrency. Controls the number of concurrent I/O operations during maintenance operations [default: 10]
   -l, --log-file <LOG_FILE>                             Log file path (default: reindexer.log in current directory) [default: reindexer.log]
       --reindex-only-bloated <PERCENTAGE>               Reindex only indexes with bloat ratio above this percentage (0-100). If not specified, all indexes will be reindexed
+      --concurrently                                     Use REINDEX INDEX CONCURRENTLY for online reindexing. Set to false to use offline reindexing (REINDEX INDEX) [default: true]
   -h, --help                                            Print help
   -V, --version                                         Print version
 ```
@@ -183,7 +184,8 @@ Options:
 - **Constraint awareness**: Automatically skips primary keys and unique constraints (which can't use CONCURRENTLY)
 
 ### ⚡ **Concurrent Operations with Safety**
-- **Non-blocking reindexing**: Uses `REINDEX INDEX CONCURRENTLY` to minimize downtime
+- **Flexible reindexing modes**: Choose between online (`REINDEX INDEX CONCURRENTLY`) or offline (`REINDEX INDEX`) reindexing
+- **Non-blocking reindexing**: Uses `REINDEX INDEX CONCURRENTLY` by default to minimize downtime
 - **Smart threading**: Multiple threads for different tables, but protects same table from concurrent operations
 - **Deadlock prevention**: Intelligent concurrent operations that allow multiple tables but protect same table from simultaneous reindex operations
 - **Configurable concurrency**: 1-32 threads with automatic validation against PostgreSQL limits

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,14 @@ struct Args {
         help = "Reindex only indexes with bloat ratio above this percentage (0-100). If not specified, all indexes will be reindexed."
     )]
     reindex_only_bloated: Option<u8>,
+
+    /// Use CONCURRENTLY for online reindexing (default: true)
+    #[arg(
+        long,
+        default_value = "false",
+        help = "Use REINDEX INDEX CONCURRENTLY for online reindexing. Set to false to use offline reindexing (REINDEX INDEX)."
+    )]
+    concurrently: bool,
 }
 
 fn get_password_from_pgpass(
@@ -523,6 +531,7 @@ async fn main() -> Result<()> {
         let max_parallel_maintenance_workers = args.max_parallel_maintenance_workers;
         let maintenance_io_concurrency = args.maintenance_io_concurrency;
         let bloat_threshold = args.reindex_only_bloated;
+        let concurrently = args.concurrently;
 
         let task = tokio::spawn(async move {
             // Acquire permit from semaphore
@@ -551,6 +560,7 @@ async fn main() -> Result<()> {
                 shared_tracker,
                 logger,
                 bloat_threshold,
+                concurrently,
             )
             .await
         });


### PR DESCRIPTION
Introduced a new argument called `concurrently`. It will control the reindex operation if enabled the program will execute reindex concurrrently, if not it will reindex by acquiring exclusive lock.