### PR TITLE
refactor: update active vacuum query to filter only manual vacuum query

### DIFF
--- a/src/queries.rs
+++ b/src/queries.rs
@@ -10,7 +10,7 @@ pub const GET_RUNNING_PGREINDEXER: &str = r#"
 pub const GET_ACTIVE_VACUUM: &str = r#"
     SELECT * FROM pg_stat_activity 
     WHERE state = 'active' 
-    AND upper(query) LIKE '%VACUUM%' 
+    AND lower(query) LIKE 'vacuum%' 
     AND pid != pg_backend_pid();
 "#;
 


### PR DESCRIPTION
- updated active vacuum query to filter only manual vacuum commands. Autovacuum commands will not prevent reindexing from being executed. 