### PR TITLE
feat: check manual active vacuum at table level before reindexing

### DIFF
--- a/src/queries.rs
+++ b/src/queries.rs
@@ -6,6 +6,7 @@ pub const GET_ACTIVE_VACUUM: &str = r#"
     SELECT * FROM pg_stat_activity 
     WHERE state = 'active' 
     AND lower(query) LIKE 'vacuum%' 
+    AND lower(query) LIKE $1
     AND pid != pg_backend_pid();
 "#;
 


### PR DESCRIPTION
- introduced a table level active manual vacuum check before executing a reindex.