### PR TITLE
feat: introduce a new argument --skip-active-vacuums to skip active vacuum validations before reindexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ pg-reindexer --schema public --threads 1 --maintenance-work-mem-gb 1 --max-paral
 pg-reindexer --schema public --threads 8 --maintenance-work-mem-gb 4 --max-parallel-maintenance-workers 4 --maintenance-io-concurrency 256
 
 # Emergency operation (maximum safety)
-pg-reindexer --schema public --threads 1 --maintenance-work-mem-gb 1 --max-parallel-maintenance-workers 1 --skip-inactive-replication-slots --skip-sync-replication-connection
+pg-reindexer --schema public --threads 1 --maintenance-work-mem-gb 1 --max-parallel-maintenance-workers 1 --skip-inactive-replication-slots --skip-sync-replication-connection --skip-active-vacuums
 ```
 
 
@@ -163,6 +163,7 @@ Options:
   -v, --verbose                                         Verbose output
   -i, --skip-inactive-replication-slots                 Skip inactive replication slots check
   -r, --skip-sync-replication-connection                Skip sync replication connection check
+      --skip-active-vacuums                              Skip active vacuum check
   -m, --max-size-gb <MAX_SIZE_GB>                      Maximum index size in GB. Indexes larger than this will be excluded from reindexing [default: 1024]
   -w, --maintenance-work-mem-gb <MAINTENANCE_WORK_MEM_GB>  Maximum maintenance work mem in GB (max: 32 GB) [default: 1]
   -x, --max-parallel-maintenance-workers <MAX_PARALLEL_MAINTENANCE_WORKERS>  Maximum parallel maintenance workers. Must be less than max_parallel_workers/2 for safety. Use 0 for PostgreSQL default (typically 2) [default: 2]

--- a/src/index_operations.rs
+++ b/src/index_operations.rs
@@ -119,6 +119,7 @@ pub async fn reindex_index_with_client(
     verbose: bool,
     skip_inactive_replication_slots: bool,
     skip_sync_replication_connection: bool,
+    skip_active_vacuums: bool,
     shared_tracker: Arc<tokio::sync::Mutex<SharedTableTracker>>,
     logger: Arc<logging::Logger>,
     bloat_threshold: Option<u8>,
@@ -288,7 +289,7 @@ pub async fn reindex_index_with_client(
     
     // Determine specific skip reason for better debugging
     let mut skip_reasons = Vec::new();
-    if reindexing_results.active_vacuum {
+    if reindexing_results.active_vacuum && !skip_active_vacuums {
         skip_reasons.push("active vacuum");
     }
     if reindexing_results.inactive_replication_slots && !skip_inactive_replication_slots {

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,14 @@ struct Args {
         help = "Skip checking sync replication connection/slot status. If there is a sync replication instance, it will be skipped.")]
     skip_sync_replication_connection: bool,
 
+    /// Skip active vacuum check
+    #[arg(
+        long, 
+        default_value = "false",
+        help = "Skip checking active vacuum processes. If there is an active vacuum process, it will be skipped."
+    )]
+    skip_active_vacuums: bool,
+
     /// Maximum index size in GB (default: 1024 GB = 1TB)
     #[arg(
         short = 'm',
@@ -533,6 +541,7 @@ async fn main() -> Result<()> {
         let verbose = args.verbose;
         let skip_inactive_replication_slots = args.skip_inactive_replication_slots;
         let skip_sync_replication_connection = args.skip_sync_replication_connection;
+        let skip_active_vacuums = args.skip_active_vacuums;
         let shared_tracker = shared_tracker.clone();
         let logger = logger.clone();
         let maintenance_work_mem_gb = args.maintenance_work_mem_gb;
@@ -564,6 +573,7 @@ async fn main() -> Result<()> {
                 verbose,
                 skip_inactive_replication_slots,
                 skip_sync_replication_connection,
+                skip_active_vacuums,
                 shared_tracker,
                 logger,
                 bloat_threshold,


### PR DESCRIPTION
-  introduce a new argument --skip-active-vacuums to skip active vacuum validations before reindexing