### PR TITLE
feat: added temp_file_limit check.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -364,6 +364,20 @@ async fn main() -> Result<()> {
         ));
     }
 
+    // Get the current temp_file_limit setting and check if it's limited or not.
+    // Warn the user if it's limited.
+    let temp_file_limit = client.query(queries::GET_TEMP_FILE_LIMIT, &[]).await.context("Failed to get temp_file_limit setting")?;
+    let temp_file_limit_str: String = temp_file_limit.first().unwrap().get(0);
+    let temp_file_limit: i128 = temp_file_limit_str
+        .parse()
+        .context("Failed to parse temp_file_limit value")?;
+    if !(temp_file_limit == -1) {
+        logger.log(logging::LogLevel::Warning, "Temp file limit is limited at database level. This may cause reindexing to fail at some point.Ensure you have set a proper temp_file_limit in your postgresql.conf file.");
+    }
+    else {
+        logger.log(logging::LogLevel::Success, "Temp file limit is not limited at database level.");
+    }
+
     logger.log(
         logging::LogLevel::Info,
         &format!("Discovering indexes in schema '{}'", args.schema),

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -1,7 +1,4 @@
 // SQL queries used throughout the application
-
-
-
 pub const GET_ACTIVE_VACUUM: &str = r#"
     SELECT * FROM pg_stat_activity 
     WHERE state = 'active' 
@@ -130,3 +127,6 @@ pub const GET_INDEX_BLOAT_RATIO: &str = r#"
         END as bloat_percentage
     FROM specific_index;
 "#;
+
+// Get the current temp_file_limit setting
+pub const GET_TEMP_FILE_LIMIT: &str = "SELECT setting FROM pg_settings WHERE name='temp_file_limit'";


### PR DESCRIPTION
- introduced temp_file_limit check which provides information to user if there is a limit or not at database level regarding the GUC. Since the reindex process may fail due to temp_file_limit. 

It's a good practice since the user can configure it if required. 