### PR TITLE
refactor: catch failure events and save it to logbook to improve visibility

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -87,6 +87,16 @@ impl Logger {
         );
     }
 
+    pub fn log_index_failed(&self, schema: &str, index: &str, reason: &str) {
+        self.log(
+            LogLevel::Error,
+            &format!(
+                "{}.{} - Reindex failed: {}",
+                schema, index, reason
+            ),
+        );
+    }
+
     pub fn log_completion_message(
         &self,
         total: usize,

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,6 +18,7 @@ pub enum ReindexStatus {
     BelowBloatThreshold,
     Skipped,
     ValidationFailed,
+    Failed,
     Success,
 }
 
@@ -28,6 +29,7 @@ impl std::fmt::Display for ReindexStatus {
             ReindexStatus::BelowBloatThreshold => write!(f, "below_bloat_threshold"),
             ReindexStatus::Skipped => write!(f, "skipped"),
             ReindexStatus::ValidationFailed => write!(f, "validation_failed"),
+            ReindexStatus::Failed => write!(f, "failed"),
             ReindexStatus::Success => write!(f, "success"),
         }
     }


### PR DESCRIPTION
when individual tasks fail (due to connection issues, validation failures, etc.), the system now logs the failure with the specific error message and attempts to save a failed record to the database