### PR TITLE
feat: add log_statements to all for this tool to debug all queries.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -21,6 +21,10 @@ pub async fn set_session_parameters(
         .execute(crate::queries::SET_APPLICATION_NAME, &[])
         .await
         .context("Set the application name.")?;
+    client
+        .execute(crate::queries::SET_LOG_STATEMENTS, &[])
+        .await
+        .context("Set log_statement to 'all'.")?;
 
     // The following operation defines the maintenance work mem in GB provided by the user.
     client

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -91,6 +91,7 @@ pub const GET_SYNC_REPLICATION_CONNECTION_COUNT: &str = r#"
 pub const SET_STATEMENT_TIMEOUT: &str = "SET statement_timeout TO 0";
 pub const SET_IDLE_SESSION_TIMEOUT: &str = "SET idle_session_timeout TO 0";
 pub const SET_APPLICATION_NAME: &str = "SET application_name TO 'reindexer'";
+pub const SET_LOG_STATEMENTS: &str = "SET log_statement TO 'all'";
 
 // Get max_parallel_workers setting
 pub const GET_MAX_PARALLEL_WORKERS: &str = "SHOW max_parallel_workers";


### PR DESCRIPTION
- introduced `log_statements` GUC to make queries executed by reindexer visible in logs if possible. 