### PR TITLE
fix-orphaned-spelling-mistake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 test_commands.sh
 reindexer.log
 QUICK_TEST_REFERENCE.md
+*.tar.gz
 
 # Binaries
 *.exe

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ pg-reindexer --schema public --reindex-only-bloated 15
 
 ```bash
 # Clean up orphaned _ccnew indexes before reindexing
-pg-reindexer --schema public --clean-orphant-indexes
+pg-reindexer --schema public --clean-orphaned-indexes
 
 # Combine with other operations
-pg-reindexer --schema public --clean-orphant-indexes --threads 4 --maintenance-work-mem-gb 2
+pg-reindexer --schema public --clean-orphaned-indexes --threads 4 --maintenance-work-mem-gb 2
 ```
 
 ### 🛡️ **Production Scenarios**
@@ -187,7 +187,7 @@ Options:
   -l, --log-file <LOG_FILE>                             Log file path (default: reindexer.log in current directory) [default: reindexer.log]
       --reindex-only-bloated <PERCENTAGE>               Reindex only indexes with bloat ratio above this percentage (0-100). If not specified, all indexes will be reindexed
       --concurrently                                     Use REINDEX INDEX CONCURRENTLY for online reindexing. Set to false to use offline reindexing (REINDEX INDEX) [default: true]
-      --clean-orphant-indexes                            Drop orphaned _ccnew indexes (temporary concurrent reindex indexes) before starting the reindexing process. These indexes are created by PostgreSQL during REINDEX INDEX CONCURRENTLY operations and may be left behind if the operation was interrupted.
+      --clean-orphaned-indexes                            Drop orphaned _ccnew indexes (temporary concurrent reindex indexes) before starting the reindexing process. These indexes are created by PostgreSQL during REINDEX INDEX CONCURRENTLY operations and may be left behind if the operation was interrupted.
   -h, --help                                            Print help
   -V, --version                                         Print version
 ```

--- a/src/index_operations.rs
+++ b/src/index_operations.rs
@@ -462,7 +462,7 @@ pub async fn reindex_index_with_memory_table(
 }
 
 /// Drop a single orphaned _ccnew index after validating it's safe to drop
-pub async fn clean_orphant_ccnew_index(
+pub async fn clean_orphaned_ccnew_index(
     client: &tokio_postgres::Client,
     schema_name: &str,
     index_name: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,7 @@ struct Args {
         default_value = "false",
         help = "Drop orphaned _ccnew indexes (temporary concurrent reindex indexes) before starting the reindexing process. These indexes are created by PostgreSQL during REINDEX INDEX CONCURRENTLY operations and may be left behind if the operation was interrupted."
     )]
-    clean_orphant_indexes: bool,
+    clean_orphaned_indexes: bool,
 }
 
 fn get_password_from_pgpass(
@@ -416,7 +416,7 @@ async fn main() -> Result<()> {
     }
 
     // Clean orphaned _ccnew indexes if requested
-    if args.clean_orphant_indexes {
+    if args.clean_orphaned_indexes {
         logger.log(
             logging::LogLevel::Info,
             "Will clean orphaned _ccnew indexes during index discovery...",
@@ -588,7 +588,7 @@ async fn main() -> Result<()> {
     let logger = Arc::new(logger);
 
     // Clean orphaned _ccnew indexes if requested
-    if args.clean_orphant_indexes {
+    if args.clean_orphaned_indexes {
         logger.log(
             logging::LogLevel::Info,
             "Cleaning orphaned _ccnew indexes...",
@@ -596,7 +596,7 @@ async fn main() -> Result<()> {
         
         for index in &indexes {
             if is_temporary_concurrent_reindex_index(&index.index_name) {
-                if let Err(e) = index_operations::clean_orphant_ccnew_index(&client, &index.schema_name, &index.index_name, &logger).await {
+                if let Err(e) = index_operations::clean_orphaned_ccnew_index(&client, &index.schema_name, &index.index_name, &logger).await {
                     logger.log(logging::LogLevel::Error, &format!("Failed to drop orphaned index {}.{}: {}", index.schema_name, index.index_name, e));
                 }
             }


### PR DESCRIPTION
- update the clean-orphant-indexes to clean-orphaned-indexes. 
- update the .gitignore file.