### PR TITLE
feat: introduce --lock-timeout-seconds cli parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ pg-reindexer --schema public --max-parallel-maintenance-workers 0
 
 # High IO concurrency
 pg-reindexer --schema public --maintenance-io-concurrency 256
+
+# Set lock timeout to 30 seconds
+pg-reindexer --schema public --lock-timeout-seconds 30
+
+# Disable lock timeout (default)
+pg-reindexer --schema public --lock-timeout-seconds 0
 ```
 
 ### 📊 **Size Filtering**
@@ -143,6 +149,9 @@ pg-reindexer --schema public --threads 8 --maintenance-work-mem-gb 4 --max-paral
 
 # Emergency operation (maximum safety)
 pg-reindexer --schema public --threads 1 --maintenance-work-mem-gb 1 --max-parallel-maintenance-workers 1 --skip-inactive-replication-slots --skip-sync-replication-connection --skip-active-vacuums
+
+# Production with lock timeout protection
+pg-reindexer --schema public --threads 2 --maintenance-work-mem-gb 2 --max-parallel-maintenance-workers 2 --lock-timeout-seconds 60
 ```
 
 
@@ -184,6 +193,7 @@ Options:
   -w, --maintenance-work-mem-gb <MAINTENANCE_WORK_MEM_GB>  Maximum maintenance work mem in GB (max: 32 GB) [default: 1]
   -x, --max-parallel-maintenance-workers <MAX_PARALLEL_MAINTENANCE_WORKERS>  Maximum parallel maintenance workers. Must be less than max_parallel_workers/2 for safety. Use 0 for PostgreSQL default (typically 2) [default: 2]
   -c, --maintenance-io-concurrency <MAINTENANCE_IO_CONCURRENCY>  Maintenance IO concurrency. Controls the number of concurrent I/O operations during maintenance operations [default: 10]
+      --lock-timeout-seconds <LOCK_TIMEOUT_SECONDS>     Lock timeout in seconds. Set to 0 for no timeout (default). This controls how long to wait for locks before timing out. [default: 0]
   -l, --log-file <LOG_FILE>                             Log file path (default: reindexer.log in current directory) [default: reindexer.log]
       --reindex-only-bloated <PERCENTAGE>               Reindex only indexes with bloat ratio above this percentage (0-100). If not specified, all indexes will be reindexed
       --concurrently                                     Use REINDEX INDEX CONCURRENTLY for online reindexing. Set to false to use offline reindexing (REINDEX INDEX) [default: true]
@@ -225,6 +235,7 @@ Options:
   - `maintenance_work_mem`: Control memory allocation for index operations (max: 32 GB)
   - `maintenance_io_concurrency`: Manage concurrent I/O operations (max: 512)
   - `max_parallel_maintenance_workers`: Control parallel worker count
+  - `lock_timeout`: Control how long to wait for locks before timing out (0 = no timeout)
 - **Resource Management**: Balance performance vs. system resource consumption
 - **Smart Defaults**: Uses PostgreSQL defaults when parameters are set to 0
 

--- a/src/index_operations.rs
+++ b/src/index_operations.rs
@@ -123,6 +123,7 @@ pub async fn worker_with_memory_table(
     maintenance_work_mem_gb: u64,
     max_parallel_maintenance_workers: u64,
     maintenance_io_concurrency: u64,
+    lock_timeout_seconds: u64,
     skip_inactive_replication_slots: bool,
     skip_sync_replication_connection: bool,
     skip_active_vacuums: bool,
@@ -140,6 +141,7 @@ pub async fn worker_with_memory_table(
         maintenance_work_mem_gb,
         max_parallel_maintenance_workers,
         maintenance_io_concurrency,
+        lock_timeout_seconds,
     )
     .await?;
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -154,6 +154,7 @@ impl Logger {
         maintenance_work_mem_gb: u64,
         max_parallel_maintenance_workers: u64,
         maintenance_io_concurrency: u64,
+        lock_timeout_seconds: u64,
     ) {
         self.log(
             LogLevel::Info,
@@ -169,6 +170,10 @@ impl Logger {
         self.log(
             LogLevel::Info,
             &format!("Maintenance IO concurrency: {}", maintenance_io_concurrency),
+        );
+        self.log(
+            LogLevel::Info,
+            &format!("Lock timeout: {} seconds", lock_timeout_seconds),
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,14 @@ struct Args {
     )]
     maintenance_io_concurrency: u64,
 
+    /// Lock timeout in seconds (default: 0 = no timeout)
+    #[arg(
+        long,
+        default_value = "0",
+        help = "Lock timeout in seconds. Set to 0 for no timeout (default). This controls how long to wait for locks before timing out."
+    )]
+    lock_timeout_seconds: u64,
+
     /// Log file path (default: reindexer.log in current directory)
     #[arg(
         short = 'l', 
@@ -523,12 +531,14 @@ async fn main() -> Result<()> {
         args.maintenance_work_mem_gb,
         args.max_parallel_maintenance_workers,
         args.maintenance_io_concurrency,
+        args.lock_timeout_seconds,
     )
     .await?;
     logger.log_session_parameters(
         args.maintenance_work_mem_gb,
         args.max_parallel_maintenance_workers,
         args.maintenance_io_concurrency,
+        args.lock_timeout_seconds,
     );
 
     logger.log(
@@ -626,6 +636,7 @@ async fn main() -> Result<()> {
         let maintenance_work_mem_gb = args.maintenance_work_mem_gb;
         let max_parallel_maintenance_workers = args.max_parallel_maintenance_workers;
         let maintenance_io_concurrency = args.maintenance_io_concurrency;
+        let lock_timeout_seconds = args.lock_timeout_seconds;
         let skip_inactive_replication_slots = args.skip_inactive_replication_slots;
         let skip_sync_replication_connection = args.skip_sync_replication_connection;
         let skip_active_vacuums = args.skip_active_vacuums;
@@ -641,6 +652,7 @@ async fn main() -> Result<()> {
                 maintenance_work_mem_gb,
                 max_parallel_maintenance_workers,
                 maintenance_io_concurrency,
+                lock_timeout_seconds,
                 skip_inactive_replication_slots,
                 skip_sync_replication_connection,
                 skip_active_vacuums,


### PR DESCRIPTION
- introduce `--lock-timeout-seconds` cli parameter to manage lock timeout to prevent reindex queries running too long and block other sessions. 