### PR TITLE
feat: introduce reindex_duration column on logbook table

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,8 @@ CREATE TABLE reindexer.reindex_logbook (
     reindex_status VARCHAR(255) NOT NULL,
     before_size BIGINT,
     after_size BIGINT,
-    size_change BIGINT
+    size_change BIGINT,
+    reindex_duration REAL
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ export PG_PASSWORD=mypassword
 
 # Then run without connection parameters
 pg-reindexer --schema public 
+
+# Possible to set your .pgass file as anv. variable instead of PGPASS env. variable.
+
+export PGPASSFILE=.pgpass
 ```
 
 ## Command Line Interface

--- a/src/index_operations.rs
+++ b/src/index_operations.rs
@@ -305,6 +305,7 @@ pub async fn reindex_index_with_memory_table(
             before_size: None,
             after_size: None,
             size_change: None,
+            reindex_duration: None,
         };
         crate::save::save_index_info(&client, &index_data).await?;
         return Ok(crate::types::ReindexStatus::InvalidIndex);
@@ -330,6 +331,7 @@ pub async fn reindex_index_with_memory_table(
                 before_size: None,
                 after_size: None,
                 size_change: None,
+                reindex_duration: None,
             };
             crate::save::save_index_info(&client, &index_data).await?;
             return Ok(crate::types::ReindexStatus::BelowBloatThreshold);
@@ -370,6 +372,7 @@ pub async fn reindex_index_with_memory_table(
             before_size: None,
             after_size: None,
             size_change: None,
+            reindex_duration: None,
         };
         crate::save::save_index_info(&client, &index_data).await?;
         return Ok(crate::types::ReindexStatus::Skipped);
@@ -410,6 +413,7 @@ pub async fn reindex_index_with_memory_table(
                 before_size: Some(before_size),
                 after_size: None,
                 size_change: None,
+                reindex_duration: Some(((duration.as_secs_f64() * 10.0).round() / 10.0) as f32),
             };
             crate::save::save_index_info(&client, &index_data).await?;
             
@@ -436,6 +440,7 @@ pub async fn reindex_index_with_memory_table(
             before_size: Some(before_size),
             after_size: Some(after_size),
             size_change: Some(size_change),
+            reindex_duration: Some(((duration.as_secs_f64() * 10.0).round() / 10.0) as f32),
         };
         crate::save::save_index_info(&client, &index_data).await?;
         return Ok(crate::types::ReindexStatus::ValidationFailed);
@@ -450,6 +455,7 @@ pub async fn reindex_index_with_memory_table(
         before_size: Some(before_size),
         after_size: Some(after_size),
         size_change: Some(size_change),
+        reindex_duration: Some(((duration.as_secs_f64() * 10.0).round() / 10.0) as f32),
     };
     crate::save::save_index_info(&client, &index_data).await?;
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -94,31 +94,12 @@ impl Logger {
     pub fn log_completion_message(
         &self,
         total: usize,
-        failed: usize,
+        _failed: usize,
         duration: std::time::Duration,
-        threads: usize,
+        _threads: usize,
     ) {
-        self.log(LogLevel::Info, "=== REINDEX COMPLETED ===");
-        self.log(
-            LogLevel::Info,
-            &format!("Total indexes processed: {}", total),
-        );
-        if failed > 0 {
-            self.log(LogLevel::Error, &format!("Failed: {}", failed));
-        }
+        self.log(LogLevel::Info, &format!("Total indexes processed: {}", total));
         self.log(LogLevel::Info, &format!("Duration: {:.2?}", duration));
-        self.log(
-            LogLevel::Info,
-            &format!("Concurrent threads used: {}", threads),
-        );
-        self.log(
-            LogLevel::Info,
-            "For detailed results, review the reindex_logbook table:",
-        );
-        self.log(
-            LogLevel::Info,
-            "SELECT * FROM reindexer.reindex_logbook WHERE reindex_time >= NOW() - INTERVAL '1 hour' ORDER BY reindex_time DESC;",
-        );
     }
 
     pub fn log_dry_run(&self, indexes: &[crate::IndexInfo]) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -754,19 +754,12 @@ async fn main() -> Result<()> {
 
     // Get final statistics from memory table
     let (pending, in_progress, completed, failed, skipped) = memory_table.get_statistics().await;
-    logger.log(
-        logging::LogLevel::Info,
-        &format!(
-            "Final statistics - Pending: {}, In Progress: {}, Completed: {}, Failed: {}, Skipped: {}",
-            pending, in_progress, completed, failed, skipped
-        ),
-    );
 
     let duration = start_time.elapsed();
 
     // Create a new logger for the final message
     let final_logger = logging::Logger::new(args.log_file.clone());
-    let total_processed = completed + failed + skipped;
+    let total_processed = completed + failed + skipped + pending + in_progress;
     final_logger.log_completion_message(total_processed, failed, duration, effective_threads);
     final_logger.log(logging::LogLevel::Success, "Reindex process completed");
 

--- a/src/save.rs
+++ b/src/save.rs
@@ -11,12 +11,13 @@ pub struct IndexData {
     pub before_size: Option<i64>,
     pub after_size: Option<i64>,
     pub size_change: Option<i64>,
+    pub reindex_duration: Option<f32>,
 }
 
 pub async fn save_index_info(client: &Client, index_data: &IndexData) -> Result<()> {
     let query = r#"
-        INSERT INTO reindexer.reindex_logbook (schema_name, index_name, index_type, reindex_status, before_size, after_size, size_change)
-        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        INSERT INTO reindexer.reindex_logbook (schema_name, index_name, index_type, reindex_status, before_size, after_size, size_change, reindex_duration)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
     "#;
 
     // need some details about the error.
@@ -31,6 +32,7 @@ pub async fn save_index_info(client: &Client, index_data: &IndexData) -> Result<
                 &index_data.before_size,
                 &index_data.after_size,
                 &index_data.size_change,
+                &index_data.reindex_duration,
             ],
         )
         .await;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -19,7 +19,8 @@ pub async fn create_index_info_table(client: &Client) -> Result<()> {
             reindex_status VARCHAR(255) NOT NULL,
             before_size BIGINT,
             after_size BIGINT,
-            size_change BIGINT
+            size_change BIGINT,
+            reindex_duration REAL
         );
     "#;
 


### PR DESCRIPTION
- introduced reindex_duration column to store each reindex operation duration at database level. 
- improve logging messages at the final stage.
- added .pgpass file env variable to documentation.