### PR TITLE
feat: harden password handling — escaping, env interpolation, CLI war…

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -6,7 +6,8 @@ host = "localhost"
 port = 5432
 database = "postgres"
 username = "postgres"
-password = "postgres"  # Consider using environment variables or .pgpass for security
+password = "${PG_PASSWORD}"  # Recommended: reference an environment variable instead of plaintext
+# password = "postgres"  # Plaintext also works but is less secure
 
 # Schema settings
 # schema = "public"  # Can be a single schema or comma-separated list

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -96,14 +96,26 @@ impl ConnectionConfig {
     pub fn build_connection_string(&self) -> String {
         let mut connection_string = format!(
             "host={} port={} dbname={} user={}",
-            self.host, self.port, self.database, self.username
+            escape_libpq_value(&self.host),
+            self.port,
+            escape_libpq_value(&self.database),
+            escape_libpq_value(&self.username),
         );
 
         if let Some(ref pwd) = self.password {
-            connection_string.push_str(&format!(" password={}", pwd));
+            connection_string.push_str(&format!(" password={}", escape_libpq_value(pwd)));
         }
 
         connection_string
+    }
+}
+
+fn escape_libpq_value(s: &str) -> String {
+    if s.chars().any(|c| c.is_whitespace() || c == '\'' || c == '\\') {
+        let escaped = s.replace('\\', "\\\\").replace('\'', "\\'");
+        format!("'{}'", escaped)
+    } else {
+        s.to_owned()
     }
 }
 
@@ -397,4 +409,39 @@ pub async fn create_connection_with_session_parameters_ssl(
     .await?;
 
     Ok(client)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_libpq_value;
+
+    #[test]
+    fn plain_alphanumeric_is_unchanged() {
+        assert_eq!(escape_libpq_value("mypassword123"), "mypassword123");
+    }
+
+    #[test]
+    fn password_with_space_is_quoted() {
+        assert_eq!(escape_libpq_value("my password"), "'my password'");
+    }
+
+    #[test]
+    fn password_with_single_quote_is_escaped() {
+        assert_eq!(escape_libpq_value("it's"), "'it\\'s'");
+    }
+
+    #[test]
+    fn password_with_backslash_is_escaped() {
+        assert_eq!(escape_libpq_value("pass\\word"), "'pass\\\\word'");
+    }
+
+    #[test]
+    fn password_with_space_and_quote_is_fully_escaped() {
+        assert_eq!(escape_libpq_value("it's alive"), "'it\\'s alive'");
+    }
+
+    #[test]
+    fn empty_string_is_unchanged() {
+        assert_eq!(escape_libpq_value(""), "");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,11 @@ struct Args {
     username: Option<String>,
 
     /// Password (can also be set via PG_PASSWORD environment variable)
-    #[arg(short = 'P', long, help = "Password for the PostgreSQL user")]
+    #[arg(
+        short = 'P',
+        long,
+        help = "Password for the PostgreSQL user. INSECURE: prefer PG_PASSWORD env var — command-line values are visible in process lists and shell history."
+    )]
     password: Option<String>,
 
     /// Schema name(s) to reindex. Can be a single schema or comma-separated list (max 512 schemas). Not required if --discover-all-schemas is used.
@@ -365,10 +369,20 @@ struct Config {
     pacing_ms: Option<u64>,
 }
 
+fn resolve_env_interpolation(value: Option<String>) -> Option<String> {
+    value.and_then(|v| {
+        if let Some(var_name) = v.strip_prefix("${").and_then(|s| s.strip_suffix('}')) {
+            std::env::var(var_name).ok()
+        } else {
+            Some(v)
+        }
+    })
+}
+
 /// Load configuration from a TOML file
 fn load_config_file(path: &str) -> Result<Config> {
     let file_path = Path::new(path);
-    
+
     // Check if file exists
     if !file_path.exists() {
         return Err(anyhow::anyhow!("Configuration file not found: {}", path));
@@ -378,8 +392,10 @@ fn load_config_file(path: &str) -> Result<Config> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read configuration file: {}", path))?;
 
-    let config = toml::from_str::<Config>(&content)
+    let mut config = toml::from_str::<Config>(&content)
         .with_context(|| format!("Failed to parse TOML configuration file: {}", path))?;
+
+    config.password = resolve_env_interpolation(config.password);
 
     Ok(config)
 }
@@ -644,6 +660,14 @@ fn ask_user_confirmation(
 #[tokio::main]
 async fn main() -> Result<()> {
     let mut args = Args::parse();
+
+    if args.password.is_some() {
+        eprintln!(
+            "Warning: passing --password on the command line is insecure \
+             (visible in process list and shell history). \
+             Use the PG_PASSWORD environment variable instead."
+        );
+    }
 
     // Dispatch subcommands before the reindex flow
     if let Some(Commands::Plan(plan_args)) = args.subcommand {

--- a/tests/cli_validation.rs
+++ b/tests/cli_validation.rs
@@ -1494,3 +1494,73 @@ pacing-ms = 100
         .code(predicate::ne(101))
         .code(predicate::ne(2));
 }
+
+// ============================================================
+// Password security tests
+// ============================================================
+
+#[test]
+fn test_password_cli_flag_emits_warning() {
+    let mut cmd = get_cmd();
+    cmd.arg("--schema")
+        .arg("public")
+        .arg("--password")
+        .arg("secret")
+        .env_clear()
+        .assert()
+        .stderr(predicate::str::contains("Warning").and(predicate::str::contains("insecure")));
+}
+
+#[test]
+fn test_no_warning_without_password_flag() {
+    // Running without --password should not print the insecure warning
+    let mut cmd = get_cmd();
+    cmd.arg("--schema")
+        .arg("public")
+        .env_clear()
+        .assert()
+        .stderr(predicate::str::contains("insecure").not());
+}
+
+#[test]
+fn test_config_file_env_interpolation() {
+    let mut config_file = Builder::new().suffix(".toml").tempfile().unwrap();
+    writeln!(
+        config_file.as_file_mut(),
+        r#"
+schema = "public"
+password = "${{PG_TEST_SECRET}}"
+"#
+    )
+    .unwrap();
+
+    let config_path = config_file.path().to_str().unwrap();
+    let mut cmd = get_cmd();
+    // Should parse cleanly (not exit code 2) when env var is set
+    cmd.arg("--config")
+        .arg(config_path)
+        .env("PG_TEST_SECRET", "hunter2")
+        .assert()
+        .code(predicate::ne(2));
+}
+
+#[test]
+fn test_config_file_literal_password_unchanged() {
+    let mut config_file = Builder::new().suffix(".toml").tempfile().unwrap();
+    writeln!(
+        config_file.as_file_mut(),
+        r#"
+schema = "public"
+password = "literalpassword"
+"#
+    )
+    .unwrap();
+
+    let config_path = config_file.path().to_str().unwrap();
+    let mut cmd = get_cmd();
+    cmd.arg("--config")
+        .arg(config_path)
+        .env_clear()
+        .assert()
+        .code(predicate::ne(2));
+}


### PR DESCRIPTION
…ning

- Fix libpq keyword=value escaping bug in build_connection_string: values containing spaces, single quotes, or backslashes are now wrapped in single quotes with proper \' and \\ escaping
- Add ${ENV_VAR} interpolation in TOML config password field so operators can reference environment variables instead of storing plaintext
- Emit a stderr warning when --password is passed on the CLI, directing users to PG_PASSWORD env var to avoid process-list and history leaks
- Update --password help text to document the security risk
- Add unit tests for escape_libpq_value covering all edge cases
- Add CLI integration tests for warning emission and env interpolation