### PR TITLE
feat: add post-reindex analyze tables support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ pg-reindexer --database mydb --schema public --host prod-db.company.com --sslmod
 # Resume an interrupted session in silence mode
 pg-reindexer --database mydb --schema public --resume --silence-mode
 
+# Run post-reindex ANALYZE on selected tables (PG14+ uses SKIP_LOCKED; older versions fall back automatically)
+pg-reindexer --database mydb --schema public --analyze-tables public.users,orders
+
 # Preview ranked index worklist before reindexing (no DB writes)
 pg-reindexer plan --database mydb --schema public --sort-by bloat,size --format json
 ```
@@ -212,6 +215,7 @@ Options:
       --pacing-ms <MS>                                  Sleep before each acquisition attempt [default: 10]
   -m, --max-size-gb <MAX_SIZE_GB>                       Maximum index size in GB [default: 1024]
       --min-size-gb <MIN_SIZE_GB>                       Minimum index size in GB [default: 0]
+      --analyze-tables <TABLES>                         Comma-separated tables to ANALYZE after reindexing; uses SKIP_LOCKED on PG14+ (fallback on older versions)
       --order-by-size <ORDER>                           Order by size: 'asc' or 'desc'
       --ask-confirmation                                Ask for confirmation before proceeding
       --index-type <INDEX_TYPE>                         'btree', 'constraint', or 'all' [default: btree]
@@ -250,6 +254,7 @@ Options:
 - **Plan subcommand**: Read-only ranked index worklist (JSON/CSV) with multi-criteria scoring — review before you run
 - **Replica lag throttling**: Adaptive acquisition pause when standby lag exceeds a threshold; hard time limit prevents indefinite waiting
 - **Pacing**: Configurable inter-acquisition sleep to reduce platform pressure during live traffic
+- **Post-reindex ANALYZE hook**: Optional `--analyze-tables` refreshes planner stats for selected tables that had completed reindex work (PG14+ uses `ANALYZE (SKIP_LOCKED)`, older versions use plain `ANALYZE`)
 
 ## Database Schema
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,6 +312,12 @@ struct Args {
     )]
     include_partitions: bool,
 
+    /// Comma-separated table names to ANALYZE after all reindexing completes.
+    /// Supports schema-qualified names (public.users) or plain names (users).
+    /// ANALYZE is only run for tables that had at least one index successfully reindexed.
+    #[arg(long, help = "Comma-separated table names to ANALYZE after reindexing. Supports schema-qualified (public.users) or plain names (users). Only tables with at least one successfully reindexed index are analyzed.")]
+    analyze_tables: Option<String>,
+
     /// Path to configuration file (TOML format). Configuration file values are overridden by CLI arguments.
     #[arg(
         short = 'C',
@@ -365,6 +371,7 @@ struct Config {
     order_by_size: Option<String>,
     ask_confirmation: Option<bool>,
     include_partitions: Option<bool>,
+    analyze_tables: Option<String>,
     max_replica_lag_bytes: Option<i64>,
     max_replica_lag_wait_secs: Option<u64>,
     pacing_ms: Option<u64>,
@@ -594,6 +601,9 @@ fn merge_config(config_file: Config, mut args: Args) -> Args {
         if args.include_partitions != include_parts {
             args.include_partitions = include_parts;
         }
+    }
+    if args.analyze_tables.is_none() {
+        args.analyze_tables = config_file.analyze_tables;
     }
     if args.max_replica_lag_bytes.is_none() {
         if let Some(v) = config_file.max_replica_lag_bytes {
@@ -1639,6 +1649,26 @@ async fn process_database(
             logging::LogLevel::Warning,
             "Reindexing cancelled by user. Use --resume flag to continue from where it left off.",
         );
+    }
+
+    // Parse --analyze-tables
+    let analyze_tables: Vec<String> = args
+        .analyze_tables
+        .as_deref()
+        .map(|s| {
+            s.split(',')
+                .map(|t| t.trim().to_string())
+                .filter(|t| !t.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Post-reindex ANALYZE phase — runs only when all workers finished without cancellation
+    if !analyze_tables.is_empty() && !was_cancelled && !*cancel_rx.borrow() {
+        let completed_tables = memory_table.get_completed_table_names().await;
+        orchestrator
+            .run_post_analyze(&schemas, &analyze_tables, &completed_tables)
+            .await;
     }
 
     // Get final statistics and log completion message

--- a/src/memory_table.rs
+++ b/src/memory_table.rs
@@ -1,5 +1,6 @@
 use crate::logging;
 use crate::types::{IndexInfo, IndexMemoryTable, IndexStatus};
+use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -180,6 +181,22 @@ impl SharedIndexMemoryTable {
         let table = self.inner.lock().await;
         !table.get_pending_indexes().is_empty()
     }
+
+    /// Returns (schema_name, table_name) pairs for every index that reached Completed state.
+    pub async fn get_completed_table_names(&self) -> HashSet<(String, String)> {
+        let table = self.inner.lock().await;
+        table
+            .indexes
+            .values()
+            .filter(|entry| entry.status == IndexStatus::Completed)
+            .map(|entry| {
+                (
+                    entry.index_info.schema_name.clone(),
+                    entry.index_info.table_name.clone(),
+                )
+            })
+            .collect()
+    }
 }
 
 impl Clone for SharedIndexMemoryTable {
@@ -189,3 +206,4 @@ impl Clone for SharedIndexMemoryTable {
         }
     }
 }
+

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -3,6 +3,7 @@
 use crate::index_operations;
 use crate::logging;
 use crate::memory_table;
+use crate::queries;
 use crate::state;
 use crate::types::{IndexFilterType, IndexInfo, LogStatement, SslMode};
 use anyhow::Result;
@@ -10,6 +11,49 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio_postgres::Client;
+
+fn analyze_sql_template_for_version(pg_version: i32) -> &'static str {
+    if pg_version >= 140000 {
+        queries::ANALYZE_TABLE_SKIP_LOCKED
+    } else {
+        queries::ANALYZE_TABLE
+    }
+}
+
+fn resolve_analyze_targets(
+    schemas: &[String],
+    analyze_tables: &[String],
+    completed_tables: &HashSet<(String, String)>,
+) -> Vec<(String, String)> {
+    let mut targets = Vec::new();
+
+    for analyze_target in analyze_tables {
+        if let Some((schema, table)) = analyze_target.split_once('.') {
+            let schema_name = schema.trim().to_string();
+            let table_name = table.trim().to_string();
+            if !schema_name.is_empty()
+                && !table_name.is_empty()
+                && completed_tables.contains(&(schema_name.clone(), table_name.clone()))
+            {
+                targets.push((schema_name, table_name));
+            }
+            continue;
+        }
+
+        let table_name = analyze_target.trim().to_string();
+        if table_name.is_empty() {
+            continue;
+        }
+
+        for schema_name in schemas {
+            if completed_tables.contains(&(schema_name.clone(), table_name.clone())) {
+                targets.push((schema_name.clone(), table_name.clone()));
+            }
+        }
+    }
+
+    targets
+}
 
 /// Worker configuration for creating worker tasks
 #[derive(Debug, Clone)]
@@ -279,5 +323,51 @@ impl ReindexOrchestrator {
             final_logger.log(logging::LogLevel::Success, "Reindex process completed");
         }
     }
+
+    pub async fn run_post_analyze(
+        &self,
+        schemas: &[String],
+        analyze_tables: &[String],
+        completed_tables: &HashSet<(String, String)>,
+    ) {
+        let pg_version: i32 = match self.client.query_one(queries::GET_PG_VERSION_NUM, &[]).await {
+            Ok(row) => row.get(0),
+            Err(e) => {
+                self.logger.log(
+                    logging::LogLevel::Warning,
+                    &format!("Skipping post-reindex ANALYZE: failed to get PostgreSQL version: {}", e),
+                );
+                return;
+            }
+        };
+
+        let sql_template = analyze_sql_template_for_version(pg_version);
+        let targets = resolve_analyze_targets(schemas, analyze_tables, completed_tables);
+
+        for (schema_name, table_name) in targets {
+            self.logger.log(
+                logging::LogLevel::Info,
+                &format!(
+                    "Running post-reindex ANALYZE on {}.{}",
+                    schema_name, table_name
+                ),
+            );
+
+            let query = sql_template
+                .replacen("{}", &schema_name, 1)
+                .replacen("{}", &table_name, 1);
+            match self.client.execute(&query, &[]).await {
+                Ok(_) => self.logger.log(
+                    logging::LogLevel::Success,
+                    &format!("ANALYZE completed for {}.{}", schema_name, table_name),
+                ),
+                Err(e) => self.logger.log(
+                    logging::LogLevel::Warning,
+                    &format!("ANALYZE failed for {}.{}: {}", schema_name, table_name, e),
+                ),
+            }
+        }
+    }
 }
+
 

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -8,6 +8,15 @@ pub const GET_ACTIVE_VACUUM: &str = r#"
     AND pid != pg_backend_pid();
 "#;
 
+/// ANALYZE with SKIP_LOCKED — PostgreSQL 14+
+pub const ANALYZE_TABLE_SKIP_LOCKED: &str = r#"ANALYZE (SKIP_LOCKED) "{}"."{}" "#;
+
+/// Plain ANALYZE — fallback for PostgreSQL < 14
+pub const ANALYZE_TABLE: &str = r#"ANALYZE "{}"."{}" "#;
+
+/// PostgreSQL server version number (for example: 140010 for 14.10)
+pub const GET_PG_VERSION_NUM: &str = "SELECT current_setting('server_version_num')::int";
+
 /// Builds the SQL query for fetching indexes based on filters
 /// 
 /// # Parameters

--- a/tests/cli_validation.rs
+++ b/tests/cli_validation.rs
@@ -1373,6 +1373,42 @@ fn test_all_new_flags_together() {
         .code(predicate::ne(2));
 }
 
+#[test]
+fn test_analyze_tables_single() {
+    let mut cmd = get_cmd();
+    cmd.arg("--schema")
+        .arg("public")
+        .arg("--analyze-tables")
+        .arg("users")
+        .env_clear()
+        .assert()
+        .code(predicate::ne(2));
+}
+
+#[test]
+fn test_analyze_tables_multiple() {
+    let mut cmd = get_cmd();
+    cmd.arg("--schema")
+        .arg("public")
+        .arg("--analyze-tables")
+        .arg("public.users,app.orders")
+        .env_clear()
+        .assert()
+        .code(predicate::ne(2));
+}
+
+#[test]
+fn test_analyze_tables_schema_qualified() {
+    let mut cmd = get_cmd();
+    cmd.arg("--schema")
+        .arg("public")
+        .arg("--analyze-tables")
+        .arg("public.orders")
+        .env_clear()
+        .assert()
+        .code(predicate::ne(2));
+}
+
 // ============================================================
 // Config file tests for new flags
 // ============================================================

--- a/tests/post_analyze_unit.rs
+++ b/tests/post_analyze_unit.rs
@@ -1,0 +1,60 @@
+use pg_reindexer::logging::Logger;
+use pg_reindexer::memory_table::SharedIndexMemoryTable;
+use pg_reindexer::queries;
+use pg_reindexer::types::{IndexInfo, LogFormat};
+use std::collections::HashSet;
+use tempfile::NamedTempFile;
+
+fn test_index(schema: &str, table: &str, index: &str) -> IndexInfo {
+    IndexInfo {
+        schema_name: schema.to_string(),
+        index_name: index.to_string(),
+        index_type: "btree".to_string(),
+        table_name: table.to_string(),
+        size_bytes: Some(1024),
+        parent_table_name: None,
+    }
+}
+
+#[tokio::test]
+async fn test_completed_table_names_only_include_completed_and_are_deduplicated() {
+    let memory_table = SharedIndexMemoryTable::new();
+    let log_file = NamedTempFile::new().unwrap();
+    let logger = Logger::new(
+        log_file.path().to_string_lossy().to_string(),
+        true,
+        LogFormat::Text,
+    );
+
+    memory_table
+        .initialize_with_indexes(vec![
+            test_index("public", "users", "users_idx_1"),
+            test_index("public", "users", "users_idx_2"),
+            test_index("public", "orders", "orders_idx_1"),
+        ])
+        .await;
+
+    memory_table
+        .release_index_and_mark_completed("public", "users_idx_1", "users", 0, &logger)
+        .await;
+    memory_table
+        .release_index_and_mark_completed("public", "users_idx_2", "users", 0, &logger)
+        .await;
+    memory_table
+        .release_index_and_mark_failed("public", "orders_idx_1", "orders", 0, &logger)
+        .await;
+
+    let completed = memory_table.get_completed_table_names().await;
+    assert_eq!(
+        completed,
+        HashSet::from([("public".to_string(), "users".to_string())])
+    );
+}
+
+#[test]
+fn test_analyze_query_constants_cover_both_paths() {
+    assert!(queries::ANALYZE_TABLE_SKIP_LOCKED.contains("SKIP_LOCKED"));
+    assert!(!queries::ANALYZE_TABLE.contains("SKIP_LOCKED"));
+    assert!(queries::ANALYZE_TABLE.contains("ANALYZE"));
+    assert!(queries::GET_PG_VERSION_NUM.contains("server_version_num"));
+}

--- a/tests/run_cargo_run_test.sh
+++ b/tests/run_cargo_run_test.sh
@@ -253,6 +253,21 @@ echo "# 44. Lock timeout setting"
 cargo run -- --schema $SCHEMA --lock-timeout-seconds 30
 echo ""
 
+echo "=== Post-Reindex ANALYZE Scenarios ==="
+echo ""
+
+echo "# 44a. Dry-run with --analyze-tables (ANALYZE phase should not run in dry-run)"
+cargo run -- --schema $SCHEMA --dry-run --analyze-tables users
+echo ""
+
+echo "# 44b. Dry-run with schema-qualified and plain table names"
+cargo run -- --schema $SCHEMA --dry-run --analyze-tables public.users,orders
+echo ""
+
+echo "# 44c. Live run with post-reindex ANALYZE targets"
+cargo run -- --schema $SCHEMA --analyze-tables public.users,orders
+echo ""
+
 echo "=== Combined Scenarios ==="
 echo ""
 

--- a/tests/run_db_tests.sh
+++ b/tests/run_db_tests.sh
@@ -7,6 +7,7 @@
 #   ./tests/run_db_tests.sh --db               # Run only DB tests
 #   ./tests/run_db_tests.sh --logging          # Run only logging/dry-run tests
 #   ./tests/run_db_tests.sh --signal           # Run only signal handling tests
+#   ./tests/run_db_tests.sh --post-analyze     # Run post-analyze unit tests only
 #   ./tests/run_db_tests.sh --all              # Run all tests (default)
 #   PG_PASSWORD=mypass ./tests/run_db_tests.sh --db
 
@@ -37,6 +38,7 @@ RUN_DB=false
 RUN_LOGGING=false
 RUN_CHAOS=false
 RUN_SIGNAL=false
+RUN_POST_ANALYZE=false
 RUN_PLAN=false
 RUN_SSL=false
 RUN_SSL_DB=false
@@ -61,6 +63,9 @@ if [ $# -gt 0 ]; then
             --signal|--signal-handling)
                 RUN_SIGNAL=true
                 ;;
+            --post-analyze|--post-analyze-unit)
+                RUN_POST_ANALYZE=true
+                ;;
             --plan|--plan-subcommand)
                 RUN_PLAN=true
                 ;;
@@ -82,6 +87,7 @@ if [ $# -gt 0 ]; then
                 echo "  --logging, --dry-run       Run logging and dry-run tests only"
                 echo "  --chaos, --chaos-tests     Run chaos tests only (requires database)"
                 echo "  --signal, --signal-handling Run signal handling tests only"
+                echo "  --post-analyze             Run post-analyze unit tests only"
                 echo "  --plan, --plan-subcommand  Run plan subcommand tests only"
                 echo "  --ssl                      Run SSL CLI tests (no DB needed)"
                 echo "  --ssl-db                   Run SSL DB integration tests (requires SSL-enabled PostgreSQL)"
@@ -117,7 +123,7 @@ if [ $# -gt 0 ]; then
 fi
 
 # If specific tests selected, don't run all
-if [ "$RUN_CLI" = true ] || [ "$RUN_DB" = true ] || [ "$RUN_LOGGING" = true ] || [ "$RUN_CHAOS" = true ] || [ "$RUN_SIGNAL" = true ] || [ "$RUN_PLAN" = true ] || [ "$RUN_SSL" = true ] || [ "$RUN_SSL_DB" = true ]; then
+if [ "$RUN_CLI" = true ] || [ "$RUN_DB" = true ] || [ "$RUN_LOGGING" = true ] || [ "$RUN_CHAOS" = true ] || [ "$RUN_SIGNAL" = true ] || [ "$RUN_POST_ANALYZE" = true ] || [ "$RUN_PLAN" = true ] || [ "$RUN_SSL" = true ] || [ "$RUN_SSL_DB" = true ]; then
     RUN_ALL=false
 fi
 
@@ -131,6 +137,7 @@ if [ "$RUN_ALL" = true ]; then
     echo "  ✓ Database Integration Tests"
     echo "  ✓ Logging and Dry-Run Tests"
     echo "  ✓ Signal Handling Tests"
+    echo "  ✓ Post-Analyze Unit Tests"
     echo "  ✓ Chaos Tests"
     echo "  ✓ Plan Subcommand Tests"
     echo "  ✓ SSL CLI Tests"
@@ -140,6 +147,7 @@ else
     [ "$RUN_DB" = true ] && echo "  ✓ Database Integration Tests"
     [ "$RUN_LOGGING" = true ] && echo "  ✓ Logging and Dry-Run Tests"
     [ "$RUN_SIGNAL" = true ] && echo "  ✓ Signal Handling Tests"
+    [ "$RUN_POST_ANALYZE" = true ] && echo "  ✓ Post-Analyze Unit Tests"
     [ "$RUN_CHAOS" = true ] && echo "  ✓ Chaos Tests"
     [ "$RUN_PLAN" = true ] && echo "  ✓ Plan Subcommand Tests"
     [ "$RUN_SSL" = true ] && echo "  ✓ SSL CLI Tests"
@@ -253,6 +261,25 @@ if [ "$RUN_ALL" = true ] || [ "$RUN_SIGNAL" = true ]; then
         echo -e "${RED}✗ Signal Handling Tests failed${NC}"
         OVERALL_SUCCESS=false
         FAILED_SUITES+=("Signal Handling")
+    fi
+    echo ""
+fi
+
+# Run Post-Analyze Unit Tests
+if [ "$RUN_ALL" = true ] || [ "$RUN_POST_ANALYZE" = true ]; then
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}Running Post-Analyze Unit Tests...${NC}"
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+
+    if cargo test --test post_analyze_unit -- --nocapture; then
+        echo ""
+        echo -e "${GREEN}✓ Post-Analyze Unit Tests passed!${NC}"
+    else
+        echo ""
+        echo -e "${RED}✗ Post-Analyze Unit Tests failed${NC}"
+        OVERALL_SUCCESS=false
+        FAILED_SUITES+=("Post-Analyze Unit")
     fi
     echo ""
 fi


### PR DESCRIPTION
Add --analyze-tables to run post-reindex ANALYZE only for tables with completed indexes, with PG14+ SKIP_LOCKED and automatic fallback for older versions.